### PR TITLE
extract 2d map, point cloud map and slam trajectory from pbstream

### DIFF
--- a/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/CMakeLists.txt
@@ -104,6 +104,8 @@ set(ALL_SRCS
   "cartographer_ros/time_conversion.cc"
   "cartographer_ros/trajectory_options.cc"
   "cartographer_ros/submap.cc"
+  "cartographer_ros/ros_map.cc"
+  "cartographer_ros/ros_map_writing_points_processor.cc"
   )
 add_library(${PROJECT_NAME} ${ALL_SRCS})
 add_subdirectory("cartographer_ros")

--- a/cartographer_ros/cartographer_ros/CMakeLists.txt
+++ b/cartographer_ros/cartographer_ros/CMakeLists.txt
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+find_package(PCL REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
+
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})
+
 add_executable(cartographer_node
   node_main.cc)
 target_include_directories(cartographer_node SYSTEM PUBLIC ${LUA_INCLUDE_DIR})
@@ -41,9 +49,29 @@ ament_target_dependencies(occupancy_grid_node
   "std_msgs"
 )
 
+google_binary(cartographer_pbstream_to_ros_map
+  SRCS
+    pbstream_to_ros_map_main.cc
+)
+
+add_executable(cartographer_pbstream_to_pcd
+  pbstream_to_pcd_main.cc)
+target_link_libraries(cartographer_pbstream_to_pcd ${PROJECT_NAME} ${PCL_LIBRARIES})
+
+add_executable(cartographer_pbstream_trajectory
+  pbstream_trajectory_main.cc)
+target_link_libraries(cartographer_pbstream_trajectory ${PROJECT_NAME})
+ament_target_dependencies(cartographer_pbstream_trajectory
+geometry_msgs
+tf2_ros
+)
+
 install(TARGETS
   cartographer_node
   occupancy_grid_node
+  cartographer_pbstream_to_ros_map
+  cartographer_pbstream_to_pcd
+  cartographer_pbstream_trajectory
   DESTINATION lib/${PROJECT_NAME})
 
 # google_binary(cartographer_assets_writer

--- a/cartographer_ros/cartographer_ros/pbstream_to_pcd_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_to_pcd_main.cc
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2020 <copyright holder> <email>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+
+#include <cartographer/io/submap_painter.h>
+#include <queue>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include "cartographer/io/proto_stream_interface.h"
+#include "cartographer/io/proto_stream.h"
+#include "cartographer/io/proto_stream_deserializer.h"
+#include "cartographer/mapping/pose_graph.h"
+#include "cartographer/mapping/3d/submap_3d.h"
+#include "cartographer/mapping/trajectory_node.h"
+#include "cartographer/mapping/proto/serialization.pb.h"
+#include <cartographer/transform/rigid_transform.h>
+#include <cartographer/sensor/range_data.h>
+#include <cartographer/io/submap_painter.h>
+#include <cartographer/io/image.h>
+#include "cartographer_ros/node_options.h"
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+DEFINE_string(pbstream_filename, "",
+              "Filename of a pbstream to draw a map from.");
+
+namespace cartographer_ros {
+namespace {
+
+void PbstreamToPcd(const std::string& pbstream_filename) {
+  ::cartographer::sensor::PointCloud high_resolution_cloud_;
+  ::cartographer::mapping::MapById<::cartographer::mapping::NodeId, ::cartographer::transform::Rigid3d> node_poses_;
+  ::cartographer::mapping::MapById<::cartographer::mapping::NodeId, ::cartographer::sensor::PointCloud> points_with_id_;
+  std::queue<::cartographer::mapping::NodeId> frame_ids_;
+
+  ::cartographer::io::ProtoStreamReader stream(pbstream_filename);
+  ::cartographer::io::ProtoStreamDeserializer deserializer(&stream);
+  ::cartographer::mapping::proto::PoseGraph pose_graph_proto =
+  deserializer.pose_graph();
+  
+  for (const ::cartographer::mapping::proto::Trajectory& trajectory_proto :
+    pose_graph_proto.trajectory())
+  {
+    for (const ::cartographer::mapping::proto::Trajectory::Node& node_proto :
+      trajectory_proto.node())
+    {
+      
+      ::cartographer::transform::Rigid3d global_pose = ::cartographer::transform::ToRigid3(node_proto.pose());
+      node_poses_.Insert(
+        ::cartographer::mapping::NodeId{ trajectory_proto.trajectory_id(), node_proto.node_index() },
+                        global_pose);    
+    }
+  }
+
+  ::cartographer::mapping::proto::SerializedData proto;
+  while (deserializer.ReadNextSerializedData(&proto)) {
+    switch (proto.data_case()) {
+      case ::cartographer::mapping::proto::SerializedData::kNode:
+      {
+        ::cartographer::mapping::proto::Node* proto_node = proto.mutable_node();
+        ::cartographer::mapping::proto::TrajectoryNodeData proto_node_data = *proto_node->mutable_node_data();
+        
+        ::cartographer::mapping::TrajectoryNode::Data node_data = ::cartographer::mapping::FromProto(proto_node_data);
+        ::cartographer::mapping::NodeId node_id{proto_node->node_id().trajectory_id(),proto_node->node_id().node_index()};
+        ::cartographer::transform::Rigid3d node_pose = node_poses_.at(node_id);
+        points_with_id_.Insert(node_id,node_data.low_resolution_point_cloud);
+        
+        ::cartographer::sensor::PointCloud temp
+          = ::cartographer::sensor::TransformPointCloud(node_data.high_resolution_point_cloud, node_pose.cast<float>());
+        high_resolution_cloud_.insert(high_resolution_cloud_.end(),temp.begin(),temp.end());
+        frame_ids_.push(node_id);
+      }
+      default: break;
+    }
+  }
+  
+  // Google Cartographer Point Cloud Origin IMU Frame
+
+  pcl::PointCloud<pcl::PointXYZ> cloud;
+  
+  cloud.width = high_resolution_cloud_.size();
+  cloud.height = 1;
+  cloud.points.resize (cloud.width * cloud.height);
+  
+  for(unsigned long int i=0; i<high_resolution_cloud_.size(); i++)
+  {
+    cloud[i].x = high_resolution_cloud_[i][0];
+    cloud[i].y = high_resolution_cloud_[i][1];
+    cloud[i].z = high_resolution_cloud_[i][2];  
+  }
+
+  pcl::io::savePCDFile ("map_pcd.pcd", cloud);
+}
+
+}  // namespace
+}  // namespace cartographer_ros
+
+int main(int argc, char** argv) {
+  FLAGS_alsologtostderr = true;
+  google::InitGoogleLogging(argv[0]);
+  google::ParseCommandLineFlags(&argc, &argv, true);
+
+  CHECK(!FLAGS_pbstream_filename.empty()) << "-pbstream_filename is missing.";
+
+  ::cartographer_ros::PbstreamToPcd(FLAGS_pbstream_filename);
+}

--- a/cartographer_ros/cartographer_ros/pbstream_trajectory_main.cc
+++ b/cartographer_ros/cartographer_ros/pbstream_trajectory_main.cc
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 The Cartographer Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <fstream>
+#include <iomanip>
+
+#include "cartographer/io/proto_stream_deserializer.h"
+#include "cartographer/transform/transform.h"
+#include "cartographer_ros/msg_conversion.h"
+#include "cartographer_ros/time_conversion.h"
+#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+
+using namespace std;
+
+DEFINE_string(input, "", "pbstream file to process");
+
+namespace cartographer_ros {
+namespace {
+
+geometry_msgs::msg::TransformStamped ToTransformStamped(
+    int64_t timestamp_uts, const std::string& parent_frame_id,
+    const std::string& child_frame_id,
+    const ::cartographer::transform::proto::Rigid3d& parent_T_child) {
+  geometry_msgs::msg::TransformStamped transform_stamped;
+  transform_stamped.header.frame_id = parent_frame_id;
+  transform_stamped.header.stamp = ::cartographer_ros::ToRos(
+      ::cartographer::common::FromUniversal(timestamp_uts));
+  transform_stamped.child_frame_id = child_frame_id;
+  transform_stamped.transform = ::cartographer_ros::ToGeometryMsgTransform(
+      ::cartographer::transform::ToRigid3(parent_T_child));
+  return transform_stamped;
+}
+
+void pbstream_trajectory(const std::string& input,
+                         const std::string& parent_frame_id) {
+  
+  std::string child_frame_id("imu_frame");
+  std::string filename("slam_trajectory_from_pbstream.txt");
+  double sec{0.0};
+  double nanosec{0.0};
+  double timestamp{0.0};
+  double x{0.0};
+  double y{0.0};
+  double z{0.0};
+  double q_x{0.0};
+  double q_y{0.0};
+  double q_z{0.0};
+  double q_w{1.0};
+
+  ofstream slam_trajectory;
+  slam_trajectory.open(filename);
+
+  slam_trajectory << "#" << " " << "filename" << " " << "=" << " " << filename << std::endl;
+  slam_trajectory << "#" << " " << "ParentFrame" << " " << "=" << " " << parent_frame_id << std::endl;
+  slam_trajectory << "#" << " " << "ChildFrame" << " " << "=" << " " << child_frame_id << std::endl;
+  slam_trajectory << "#" << " " << "timestamp" << " " << "x" << " " << "y" << " " << "z" << " " << "q_x" << " " << "q_y" << " " << "q_z" << " " << "q_w" << std::endl;
+
+  const auto pose_graph =
+      ::cartographer::io::DeserializePoseGraphFromFile(input);
+
+  for (const auto trajectory : pose_graph.trajectory()) {
+    LOG(INFO)
+        << trajectory.trajectory_id() << " with " << trajectory.node_size()
+        << " nodes.";
+    for (const auto& node : trajectory.node()) {
+      geometry_msgs::msg::TransformStamped transform_stamped = ToTransformStamped(node.timestamp(), parent_frame_id, child_frame_id, node.pose());
+
+      sec = transform_stamped.header.stamp.sec*1.0;
+      nanosec = transform_stamped.header.stamp.nanosec*1.0*pow(10.0,-9.0);
+      timestamp = sec + nanosec;
+      x = transform_stamped.transform.translation.x,
+      y = transform_stamped.transform.translation.y;
+      z = transform_stamped.transform.translation.z;
+      q_x = transform_stamped.transform.rotation.x;
+      q_y = transform_stamped.transform.rotation.y;
+      q_z = transform_stamped.transform.rotation.z;
+      q_w = transform_stamped.transform.rotation.w;
+
+      slam_trajectory << std::fixed << std::setprecision(9) << timestamp << " " << x << " " << y << " " << z << " " << q_x << " " << q_y << " " << q_z << " " << q_w << std::endl;
+    }
+  }
+  slam_trajectory.close();
+}
+
+}  // namespace
+}  // namespace cartographer_ros
+
+int main(int argc, char* argv[]) {
+  FLAGS_alsologtostderr = true;
+  google::InitGoogleLogging(argv[0]);
+  
+  google::ParseCommandLineFlags(&argc, &argv, true);
+  CHECK(!FLAGS_input.empty()) << "-input pbstream is missing.";
+  
+  ::cartographer_ros::pbstream_trajectory(FLAGS_input, "map");
+}


### PR DESCRIPTION
Code added to extract 2d map, point cloud map and slam trajectory from pbstream.

1. 2D map - `ros2 run cartographer_ros cartographer_pbstream_to_ros_map -pbstream_filename your_pbstream.pbstream`
2. Point cloud map (PCD file) - `ros2 run cartographer_ros cartographer_pbstream_to_pcd -pbstream_filename your_pbstream.pbstream` 
3. SLAM trajectory (TXT file containing 6D poses containing timestamp, xyz translation and xyzw quaternion rotation) - `ros2 run cartographer_ros cartographer_pbstream_trajectory -input your_pbstream.pbstream`

References

1. https://github.com/cyy1992/temp_ws/blob/26f05d364b433c04d8cee30dd8c8da1b6c8efcc7/src/test6/src/merge_cloud_from_pbstream.h
2. https://github.com/cartographer-project/cartographer_ros/blob/master/cartographer_ros/cartographer_ros/dev/pbstream_trajectories_to_rosbag_main.cc
